### PR TITLE
Class-Name update

### DIFF
--- a/th_prim_queue.rb
+++ b/th_prim_queue.rb
@@ -1,6 +1,6 @@
 require 'thread'
 
-class th_prim_queue
+class Th_prim_queue
 
   def initialize(elems=nil, &block)
     @mtx = Mutex.new


### PR DESCRIPTION
Corrects SyntaxError: a.rb:3: class/module name must be CONSTANT